### PR TITLE
fix: make stack size of a2dp thread larger

### DIFF
--- a/components/bluetooth_service/include/a2dp_stream.h
+++ b/components/bluetooth_service/include/a2dp_stream.h
@@ -61,7 +61,7 @@ typedef struct {
 /**
  * a2dp task is only created in a2dp sink mode
  */
-#define A2DP_STREAM_TASK_STACK          ( 2 * 1024 )
+#define A2DP_STREAM_TASK_STACK          ( 2200 ) // minimal is 2112 to avoid stack overflow
 #define A2DP_STREAM_TASK_CORE           ( 0 )
 #define A2DP_STREAM_TASK_PRIO           ( 22 )
 #define A2DP_STREAM_TASK_IN_EXT         ( true )


### PR DESCRIPTION
stack size was too small due to logging used in audio_element.c 

audio_element.c -> line 437
ESP_LOGW(TAG, "OUT-[%s] AEL_IO_ABORT", el->tag);