### PR TITLE
fix(http+audio): return http timeout to 20 seconds + add 1ms delay in downmix to prevent starvation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "components/esp-adf-libs"]
 	path = components/esp-adf-libs
-	url = https://github.com/espressif/esp-adf-libs
+	url = https://github.com/Sond-Org/esp-adf-libs
 [submodule "components/esp-sr"]
 	path = components/esp-sr
 	url = https://github.com/espressif/esp-sr.git

--- a/components/audio_stream/http_stream.c
+++ b/components/audio_stream/http_stream.c
@@ -579,7 +579,7 @@ _stream_open_begin:
             .url = uri,
             .event_handler = _http_event_handle,
             .user_data = self,
-            .timeout_ms = 30 * 1000,
+            .timeout_ms = 20 * 1000,
             .buffer_size = HTTP_STREAM_BUFFER_SIZE,
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 1, 0)
             .buffer_size_tx = 2024,


### PR DESCRIPTION
- **chore(deps): switch esp-adf-libs to Sond-Org fork at sond branch**
- **fix(http): reduce http timeout to 20 seconds**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes an external dependency source (submodule fork) and alters HTTP timeout behavior, which can affect streaming reliability and reconnection timing.
> 
> **Overview**
> Updates the `components/esp-adf-libs` git submodule URL to point to the `Sond-Org` fork instead of the upstream Espressif repo.
> 
> Adjusts `http_stream` HTTP client configuration to use a **20s** request timeout (down from **30s**) when initializing `esp_http_client`, changing how quickly stalled/slow connections are treated as failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6ea0146d963d89ca2b827529650ab0b39bb66c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->